### PR TITLE
Modify clearing behavior of id highlighting

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,7 +19,7 @@ const App: FC<AppProps> = ({ user, classItems }): JSX.Element => {
   // Hacky workaround because something with React probably interferes with the default browser behavior
   // Also, reactivates the highlight on the course element
   useEffect(() => {
-    const jumpId = window.location.hash.replace('#', '');
+    const jumpId = window.location.hash;
     window.location.hash = '';
     window.location.hash = jumpId;
   }, []);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -211,9 +211,7 @@ const filterCourses = (): void => {
       });
 
     renderDOM(renderedElements);
-    const jumpId = window.location.hash;
     window.location.hash = '';
-    window.location.hash = jumpId;
   }, 20);
 };
 


### PR DESCRIPTION
Because I want it to clear when using the search bar or selecting a different tag instead. It matches the behavior of documentation generators like sphinx with furo or whatever.